### PR TITLE
Placeholders should have UPPER_UNDERSCORE names in generated xtb file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 Generate/append XTB (translation XML file) for google closure compiler https://developers.google.com/closure/compiler/
 
 ## XTB file
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="cs">
     <translation id="1234567890">Message ...</translation>
+    <translation id="1234567891">Message with <ph name="PLACE_HOLDER" />.</translation>
     ...
 </translationbundle>
 ```
@@ -16,6 +17,9 @@ Generate/append XTB (translation XML file) for google closure compiler https://d
 ```javascript
 /** @desc Description for Test 1 */
 var MSG_TEST_1 = goog.getMsg('Test 1');
+
+/** @desc Message with placeholder */
+var MSG_TEST_2 = goog.getMsg('Message with {$placeHolder}.', {placeHolder: 'replaced text'});
 ```
 
 ## Usage

--- a/src/main/java/sk/kuzmisin/xtbgenerator/XtbWriter.java
+++ b/src/main/java/sk/kuzmisin/xtbgenerator/XtbWriter.java
@@ -1,5 +1,6 @@
 package sk.kuzmisin.xtbgenerator;
 
+import com.google.common.base.CaseFormat;
 import com.google.javascript.jscomp.JsMessage;
 
 import java.io.IOException;
@@ -46,7 +47,8 @@ abstract class XtbWriter {
 
             for (CharSequence part : message.parts()) {
                 if (part instanceof JsMessage.PlaceholderReference) {
-                    writer.append("<ph name=\"" + ((JsMessage.PlaceholderReference) part).getName() + "\" />");
+                    String name = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, ((JsMessage.PlaceholderReference) part).getName());
+                    writer.append("<ph name=\"" + name + "\" />");
                 } else {
                     writer.append(escape(part));
                 }

--- a/src/test/java/sk/kuzmisin/xtbgenerator/XtbWriterTest.java
+++ b/src/test/java/sk/kuzmisin/xtbgenerator/XtbWriterTest.java
@@ -68,7 +68,7 @@ public class XtbWriterTest {
 
         final String expected =
                 "\t<translation id=\"2426017083238799036\" key=\"MSG_TEST_1\" source=\"file.js\" desc=\"Description 1\">Test 1</translation>\n" +
-                "\t<translation id=\"3160123618072793522\" key=\"MSG_TEST_2\" source=\"file.js\" desc=\"Description 2\">Test 2 <ph name=\"ph1\" /> continue message <ph name=\"ph2\" /></translation>\n" +
+                "\t<translation id=\"3160123618072793522\" key=\"MSG_TEST_2\" source=\"file.js\" desc=\"Description 2\">Test 2 <ph name=\"PH1\" /> continue message <ph name=\"PH2\" /></translation>\n" +
                 "\t<translation id=\"7594360968243980581\" key=\"MSG_TEST_3\" source=\"file.js\" desc=\"Description 3\">HTML &lt;&gt; &amp;</translation>\n";
 
         assertEquals(expected, writer.toString());

--- a/src/test/java/sk/kuzmisin/xtbgenerator/XtbWriterTest.java
+++ b/src/test/java/sk/kuzmisin/xtbgenerator/XtbWriterTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -28,7 +28,7 @@ public class XtbWriterTest {
 
     @Test
     public void testWriteMessages() throws Exception {
-        Map<String, JsMessage> messages = new HashMap<>();
+        Map<String, JsMessage> messages = new LinkedHashMap<>();
         GoogleJsMessageIdGenerator idGenerator = new GoogleJsMessageIdGenerator(null);
 
         messages.put(

--- a/src/test/resources/messages.xtb
+++ b/src/test/resources/messages.xtb
@@ -2,7 +2,7 @@
 <!DOCTYPE translationbundle>
 <translationbundle lang="cs">
 	<translation id="2426017083238799036" key="MSG_TEST_1" source="messages.js" desc="Description for Test 1">Test 1</translation>
-	<translation id="4621514753271441478" key="MSG_TEST_2" source="messages.js" desc="Description for Test 2 with placeholders">Test 1 <ph name="ph1" /> and <ph name="ph2" /></translation>
+	<translation id="4621514753271441478" key="MSG_TEST_2" source="messages.js" desc="Description for Test 2 with placeholders">Test 1 <ph name="PH1" /> and <ph name="PH2" /></translation>
 	<translation id="3944534681643344567" key="MSG_TEST_3" source="messages.js" desc="Description for Test 3 with multi line description">Test 3</translation>
 	<translation id="8689970563259150743" key="MSG_TEST_4" source="messages.js" desc="Description for Test 4 HTML">Test 4 &lt;br /&gt; new HTML line</translation>
 </translationbundle>

--- a/src/test/resources/messages_append.xtb
+++ b/src/test/resources/messages_append.xtb
@@ -2,7 +2,7 @@
 <!DOCTYPE translationbundle>
 <translationbundle lang="cs">
 	<translation id="2426017083238799036" key="MSG_TEST_1" source="messages.js" desc="Description for Test 1">Test 1</translation>
-	<translation id="4621514753271441478" key="MSG_TEST_2" source="messages.js" desc="Description for Test 2 with placeholders">Test 1 <ph name="ph1" /> and <ph name="ph2" /></translation>
+	<translation id="4621514753271441478" key="MSG_TEST_2" source="messages.js" desc="Description for Test 2 with placeholders">Test 1 <ph name="PH1" /> and <ph name="PH2" /></translation>
 	<translation id="3944534681643344567" key="MSG_TEST_3" source="messages.js" desc="Description for Test 3 with multi line description">Test 3</translation>
 	<translation id="8689970563259150743" key="MSG_TEST_4" source="messages.js" desc="Description for Test 4 HTML">Test 4 &lt;br /&gt; new HTML line</translation>
 	<translation id="8934769802850633699" key="MSG_TEST_5" source="messages2add.js" desc="Description for Test 5">Test 5</translation>


### PR DESCRIPTION
This is needed to conform with Google Closure Compiler internals as seen in [XtbMessageBundleTest.java](https://github.com/google/closure-compiler/blob/a1488d59c11fd535ded79d37c11cd418927782ce/test/com/google/javascript/jscomp/XtbMessageBundleTest.java#L42) and [XtbMessageBundle.java](https://github.com/google/closure-compiler/blob/a1488d59c11fd535ded79d37c11cd418927782ce/src/com/google/javascript/jscomp/XtbMessageBundle.java#L167) files.

Otherwise errors like following occurs with automatic placeholders generated from soy templates.

```
ERROR - Message parse tree malformed. Unrecognized message placeholder referenced: startlink
        {'startLink': '<a href="' + soy.$$escapeHtml(...
        ^
```

